### PR TITLE
Playing with ablog as an extension to Sphinx

### DIFF
--- a/.templates/layout.html
+++ b/.templates/layout.html
@@ -1,22 +1,15 @@
-{% extends "sphinx_rtd_theme/layout.html" %}
-
-{% block extrahead -%}
-    {% if feed_link %}
-    <link rel="alternate" type="application/atom+xml" title="Updated items" href="/updates.atom" />
-    {%- endif %}
-{%- endblock %}
+{% extends "alabaster/layout.html" %}
 
 {%- block extrabody %}
     {%- if pagename is not index %}
-    <div class="admonition note">
-        <p class="first admonition-title">
+        <p class="readtime">
             {#-
-                Super rough reading time estimation, but I appreciate it when
-                others do the something similar.
+                Super rough reading time estimation, but I appreciate it
+                when others do the something similar.
             #}
-            Estimated reading time: {{ super() | wordcount // 500 + 1 }} minutes
+            <b>Estimated reading time</b>:
+            {{ super() | wordcount // 500 + 1 }} minutes
         </p>
-    </div>
     {% endif %}
     {{ super() }}
 {%- endblock %}

--- a/articles/dropping_gentoo.rst
+++ b/articles/dropping_gentoo.rst
@@ -1,5 +1,5 @@
-:tags: gentoo, work, linux
-:date: 2014-06-18
+.. post:: 2014-06-18
+   :tags: gentoo, work, linux
 
 Dropping Gentoo
 ===============

--- a/articles/dropping_gentoo_reflex.rst
+++ b/articles/dropping_gentoo_reflex.rst
@@ -1,5 +1,5 @@
-:tags: gentoo, work, linux
-:date: 2014-06-29
+.. post:: 2014-06-29
+   :tags: gentoo, work, linux
 
 Dropping Gentoo reflex
 ======================

--- a/articles/fossil.rst
+++ b/articles/fossil.rst
@@ -1,5 +1,5 @@
-:date: 2014-11-12
-:tags: fossil, vcs, projects, development
+.. post:: 2014-11-12
+   :tags: fossil, vcs, projects, development
 
 :command:`fossil` experiments
 =============================

--- a/articles/mutt_config_snippets.rst
+++ b/articles/mutt_config_snippets.rst
@@ -1,6 +1,5 @@
-:tags: software, configs, mutt
-:description: Small snippets of my :command:`mutt` configuration
-:date: 2007-03-05
+.. post:: 2007-03-05
+   :tags: software, configs, mutt
 
 :command:`mutt` configuration snippets
 ======================================

--- a/articles/probits/index.rst
+++ b/articles/probits/index.rst
@@ -1,5 +1,5 @@
-:date: 2014-06-30
-:tags: probit
+.. post:: 2014-06-30
+   :tags: probit
 
 Project postmortems
 ===================

--- a/articles/probits/jnrowe-misc.rst
+++ b/articles/probits/jnrowe-misc.rst
@@ -1,5 +1,5 @@
-:tags: jnrowe-misc, gentoo
-:date: 2014-06-30
+.. post:: 2014-06-30
+   :tags: jnrowe-misc, gentoo
 
 jnrowe-misc - The unsorted package overlay
 ==========================================

--- a/articles/rcs.rst
+++ b/articles/rcs.rst
@@ -1,5 +1,5 @@
-:date: 2003-09-05
-:tags: vcs
+.. post:: 2003-09-05
+   :tags: vcs
 
 Introduction to |RCS|
 =====================

--- a/articles/tdd_distros.rst
+++ b/articles/tdd_distros.rst
@@ -1,5 +1,5 @@
-:date: 2011-06-13
-:tags: devel, testing
+.. post:: 2011-06-13
+   :tags: devel, testing
 
 |TDD| distro development
 ========================

--- a/articles/tips/BTS_as_a_task_manager.rst
+++ b/articles/tips/BTS_as_a_task_manager.rst
@@ -1,5 +1,5 @@
-:date: 2009-10-07
-:tags: bts, devel
+.. post:: 2009-10-07
+   :tags: bts, devel
 
 |BTS| as a task manager
 =======================

--- a/articles/tips/Beyond_tab_completion.rst
+++ b/articles/tips/Beyond_tab_completion.rst
@@ -1,5 +1,5 @@
-:date: 2009-09-30
-:tags: bash, readline
+.. post:: 2009-09-30
+   :tags: bash, readline
 
 Beyond simple tab completion
 ============================

--- a/articles/tips/Bugzilla_real_names.rst
+++ b/articles/tips/Bugzilla_real_names.rst
@@ -1,5 +1,5 @@
-:date: 2009-09-27
-:tags: bugzilla, mail
+.. post:: 2009-09-27
+   :tags: bugzilla, mail
 
 Bugzilla mail with real names
 =============================

--- a/articles/tips/Compiling_in_vim.rst
+++ b/articles/tips/Compiling_in_vim.rst
@@ -1,5 +1,5 @@
-:date: 2009-09-24
-:tags: vim
+.. post:: 2009-09-24
+   :tags: vim
 
 Compiling C source in vim
 =========================

--- a/articles/tips/Context_aware_diffs_with_git.rst
+++ b/articles/tips/Context_aware_diffs_with_git.rst
@@ -1,5 +1,5 @@
-:date: 2009-09-29
-:tags: git
+.. post:: 2009-09-29
+   :tags: git
 
 Context aware diffs with git
 ============================

--- a/articles/tips/Custom_locations_in_the_GTK_filechooser.rst
+++ b/articles/tips/Custom_locations_in_the_GTK_filechooser.rst
@@ -1,5 +1,5 @@
-:date: 2009-10-01
-:tags: GTK+
+.. post:: 2009-10-01
+   :tags: GTK+
 
 Custom keybindings in the GTK+ file dialogs
 ===========================================

--- a/articles/tips/Debugging_python_regexps.rst
+++ b/articles/tips/Debugging_python_regexps.rst
@@ -1,5 +1,5 @@
-:date: 2009-10-29
-:tags: python
+.. post:: 2009-10-29
+   :tags: python
 
 Debugging Python |RegEx|
 ========================

--- a/articles/tips/Disabling_cursor_blinking_in_GTK.rst
+++ b/articles/tips/Disabling_cursor_blinking_in_GTK.rst
@@ -1,5 +1,5 @@
-:date: 2009-10-03
-:tags: GTK+, styling
+.. post:: 2009-10-03
+   :tags: GTK+, styling
 
 Disabling cursor blinking in GTK+
 =================================

--- a/articles/tips/Fancy_awesome_theming.rst
+++ b/articles/tips/Fancy_awesome_theming.rst
@@ -1,5 +1,5 @@
-:date: 2009-09-28
-:tags: awesome, styling
+.. post:: 2009-09-28
+   :tags: awesome, styling
 
 Fancy awesome theming
 =====================

--- a/articles/tips/Finding_a_windows_owner.rst
+++ b/articles/tips/Finding_a_windows_owner.rst
@@ -1,5 +1,5 @@
-:date: 2009-10-06
-:tags: X11
+.. post:: 2009-10-06
+   :tags: X11
 
 Finding a window’s owner
 ========================

--- a/articles/tips/Formatting_csv_files_in_the_shell.rst
+++ b/articles/tips/Formatting_csv_files_in_the_shell.rst
@@ -1,5 +1,5 @@
-:date: 2009-10-10
-:tags: csv, unix
+.. post:: 2009-10-10
+   :tags: csv, unix
 
 Formatting |CSV| files in the shell
 ===================================

--- a/articles/tips/Gentoo_one_liners.rst
+++ b/articles/tips/Gentoo_one_liners.rst
@@ -1,5 +1,5 @@
-:date: 2009-10-09
-:tags: gentoo
+.. post:: 2009-10-09
+   :tags: gentoo
 
 Gentoo one liners
 =================

--- a/articles/tips/Importing_gmail_filters_in_mutt.rst
+++ b/articles/tips/Importing_gmail_filters_in_mutt.rst
@@ -1,5 +1,5 @@
-:date: 2009-10-08
-:tags: gmail, mutt
+.. post:: 2009-10-08
+   :tags: gmail, mutt
 
 Importing gmail filters in mutt
 ===============================

--- a/articles/tips/Instant_web_server.rst
+++ b/articles/tips/Instant_web_server.rst
@@ -1,5 +1,5 @@
-:date: 2009-10-12
-:tags: devel, web
+.. post:: 2009-10-12
+   :tags: devel, web
 
 Instant web server
 ==================

--- a/articles/tips/Kick_me_birthday_reminders.rst
+++ b/articles/tips/Kick_me_birthday_reminders.rst
@@ -1,5 +1,5 @@
-:date: 2009-09-26
-:tags: abook, remind
+.. post:: 2009-09-26
+   :tags: abook, remind
 
 “Kick me” birthday reminders
 ============================

--- a/articles/tips/Making_a_nice_home.rst
+++ b/articles/tips/Making_a_nice_home.rst
@@ -1,5 +1,5 @@
-:date: 2009-10-11
-:tags: unix, vcs
+.. post:: 2009-10-11
+   :tags: unix, vcs
 
 Making a nice home
 ------------------

--- a/articles/tips/Populating_sup_contacts_from_abook.rst
+++ b/articles/tips/Populating_sup_contacts_from_abook.rst
@@ -1,5 +1,5 @@
-:date: 2010-03-23
-:tags: abook, mail, sup
+.. post:: 2010-03-23
+   :tags: abook, mail, sup
 
 Populating :command:`sup` contacts from abook
 =============================================

--- a/articles/tips/Sharing_Xresources_between_systems.rst
+++ b/articles/tips/Sharing_Xresources_between_systems.rst
@@ -1,5 +1,5 @@
-:date: 2009-10-05
-:tags: X11, styling
+.. post:: 2009-10-05
+   :tags: X11, styling
 
 Sharing Xresources between systems
 ==================================

--- a/articles/tips/Simple_notifications_in_awesome.rst
+++ b/articles/tips/Simple_notifications_in_awesome.rst
@@ -1,5 +1,5 @@
-:date: 2009-10-04
-:tags: awesome
+.. post:: 2009-10-04
+   :tags: awesome
 
 Simple notifications in awesome
 -------------------------------

--- a/articles/tips/Theming_mutt.rst
+++ b/articles/tips/Theming_mutt.rst
@@ -1,5 +1,5 @@
-:date: 2009-09-23
-:tags: mutt, styling
+.. post:: 2009-09-23
+   :tags: mutt, styling
 
 Theming mutt
 ============

--- a/articles/tips/Three_mobile_broadband_in_linux.rst
+++ b/articles/tips/Three_mobile_broadband_in_linux.rst
@@ -1,5 +1,5 @@
-:date: 2009-10-14
-:tags: linux, three
+.. post:: 2009-10-14
+   :tags: linux, three
 
 Three mobile broadband in Linux
 ===============================

--- a/articles/tips/Toggling_settings_in_vim.rst
+++ b/articles/tips/Toggling_settings_in_vim.rst
@@ -1,5 +1,5 @@
-:date: 2009-10-02
-:tags: vim
+.. post:: 2009-10-02
+   :tags: vim
 
 Toggling settings in vim
 ========================

--- a/articles/tips/Uber_pink_prompts.rst
+++ b/articles/tips/Uber_pink_prompts.rst
@@ -1,5 +1,5 @@
-:date: 2009-09-25
-:tags: bash, styling
+.. post:: 2009-09-25
+   :tags: bash, styling
 
 Uber pink prompts
 =================

--- a/articles/tips/Visual_vim_mode_identifier.rst
+++ b/articles/tips/Visual_vim_mode_identifier.rst
@@ -1,5 +1,5 @@
-:date: 2009-10-13
-:tags: awesome, vim
+.. post:: 2009-10-13
+   :tags: awesome, vim
 
 Visual vim mode identifier
 ==========================

--- a/articles/tips/Zsh_and_the_vcs.rst
+++ b/articles/tips/Zsh_and_the_vcs.rst
@@ -1,5 +1,5 @@
-:date: 2009-10-28
-:tags: git, vcs, zsh
+.. post:: 2009-10-28
+   :tags: git, vcs, zsh
 
 Zsh and the |VCS|
 =================

--- a/articles/tips/emacs_gtk_shortcuts.rst
+++ b/articles/tips/emacs_gtk_shortcuts.rst
@@ -1,6 +1,5 @@
-:description: How to change keyboard shortcuts with GTK+
-:tags: software, configs, GTK+, emacs
-:date: 2007-03-05
+.. post:: 2007-03-05
+   :tags: software, configs, GTK+, emacs
 
 Proper keyboard shortcuts in GTK+
 =================================

--- a/conf.py
+++ b/conf.py
@@ -7,7 +7,8 @@ import sys
 from contextlib import suppress
 from subprocess import CalledProcessError, PIPE, run
 
-import sphinx_rtd_theme
+import ablog
+import alabaster
 
 sys.path.extend([os.path.curdir, os.path.pardir])
 
@@ -17,7 +18,7 @@ extensions = \
      for ext in ['extlinks', 'githubpages', 'intersphinx', ]] + \
     ['sphinxcontrib.%s' % ext for ext in []] + \
     ['ext.%s' % ext for ext in ['jinja', ]] + \
-    ['feed', ]
+    ['ablog', 'alabaster']
 
 # Only activate spelling if it is installed.  It is not required in the
 # general case and we don’t have the granularity to describe this in a clean
@@ -33,7 +34,7 @@ master_doc = 'index'
 
 exclude_patterns = ['README.rst', '.build', 'draft']
 
-templates_path = ['.templates', ]
+templates_path = ['.templates', ablog.get_html_templates_path()]
 
 rst_epilog = """
 .. |CLA| replace:: :abbr:`CLA (Contributor License Agreement)`
@@ -62,12 +63,21 @@ copyright = '2009-2017  James Rowe'
 version = '0.1'
 release = '0.1.0'
 
+pygments_style = 'monokai'
+
 trim_footnote_reference_space = True
 # }}}
 
 # Options for HTML output {{{
-html_theme = 'sphinx_rtd_theme'
-html_theme_path = [sphinx_rtd_theme.get_html_theme_path(), ]
+html_theme = 'alabaster'
+html_theme_options = {
+    'pre_bg': '#272822',
+    'font_family': '"Verdana", "Arial", sans-serif',
+    'head_font_family': '"Times", "Calibri", serif',
+    'logo': 'logo.png',
+    'show_related': True,
+}
+html_theme_path = [alabaster.get_path(), ]
 
 html_title = 'JNRowe'
 
@@ -94,13 +104,22 @@ extlinks = {
 }
 # }}}
 
-# feed extension settings {{{
-feed_base_url = 'https://jnrowe.github.io'
-feed_description = 'Ramblings of a tired mind'
-feed_filename = 'updates.atom'
-feed_link_url = 'https://jnrowe.github.io/updates.atom'
-feed_type = 'atom+dc'
-feed_url = 'https://jnrowe.github.io/'
+# ablog extension settings {{{
+blog_title = project
+blog_baseurl = 'https://jnrowe.github.io/'
+post_date_format = '%F'
+post_redirect_refresh = 1
+
+html_sidebars = {
+    '**': ['about.html', 'postcard.html', 'navigation.html',
+           'recentposts.html', 'tagcloud.html', 'categories.html',
+           'archives.html', 'searchbox.html'],
+}
+
+blog_feed_archives = True
+blog_feed_fulltext = True
+blog_feed_subtitle = 'Ramblings of a tired mind'
+blog_feed_length = 15
 # }}}
 
 # intersphinx extension settings {{{

--- a/thoughts/burn_out.rst
+++ b/thoughts/burn_out.rst
@@ -1,5 +1,5 @@
-:date: 2014-09-03
-:tags: oss, burnout, life
+.. post:: 2014-09-03
+   :tags: oss, burnout, life
 
 Open Source and enjoyment
 =========================

--- a/thoughts/delayed_flashover.rst
+++ b/thoughts/delayed_flashover.rst
@@ -1,5 +1,5 @@
-:date: 2014-04-09
-:tags: life
+.. post:: 2014-04-09
+   :tags: life
 
 Delayed flashover
 =================

--- a/thoughts/disconnect.rst
+++ b/thoughts/disconnect.rst
@@ -1,5 +1,5 @@
-:tags: focus, denoise, net
-:date: 2014-09-18
+.. post:: 2014-09-18
+   :tags: focus, denoise, net
 
 Cleanse thy soul
 ================

--- a/thoughts/dopplr_effects.rst
+++ b/thoughts/dopplr_effects.rst
@@ -1,5 +1,5 @@
-:date: 2014-01-06
-:tags: history, privacy
+.. post:: 2014-01-06
+   :tags: history, privacy
 
 .. This is probably the start of something else, we’ll see.
 

--- a/thoughts/important_balance.rst
+++ b/thoughts/important_balance.rst
@@ -1,5 +1,5 @@
-:date: 2014-01-25
-:tags: life
+.. post:: 2014-01-25
+   :tags: life
 
 Murdering morality with ferocious fire
 ======================================

--- a/thoughts/metro_city.rst
+++ b/thoughts/metro_city.rst
@@ -1,5 +1,5 @@
-:date: 2017-09-03
-:tags: politics, noise
+.. post:: 2017-09-03
+   :tags: politics, noise
 
 Burning down the streets
 ========================

--- a/thoughts/nice_stories.rst
+++ b/thoughts/nice_stories.rst
@@ -1,5 +1,5 @@
-:date: 2013-12-23
-:tags: life
+.. post:: 2013-12-23
+   :tags: life
 
 Tell me a nice story, please
 ============================

--- a/thoughts/reset_in_ten.rst
+++ b/thoughts/reset_in_ten.rst
@@ -1,5 +1,5 @@
-:date: 2014-02-24
-:tags: life
+.. post:: 2014-02-24
+   :tags: life
 
 Hitting life’s reset button
 ===========================

--- a/thoughts/side_projects.rst
+++ b/thoughts/side_projects.rst
@@ -1,5 +1,5 @@
-:date: 2013-12-16
-:tags: hobbies, projects
+.. post:: 2013-12-16
+   :tags: hobbies, projects
 
 Side-projects
 =============

--- a/thoughts/the_returned.rst
+++ b/thoughts/the_returned.rst
@@ -1,5 +1,5 @@
-:date: 2014-01-27
-:tags: blog, site
+.. post:: 2014-01-27
+   :tags: blog, site
 
 Return to rambling
 ==================


### PR DESCRIPTION
As I told myself in #2, I *love* Sphinx.  `ablog` means I can keep Sphinx, and mostly have the functionality I want.

Sadly, `ablog` looks dead upstream and there are a few issues with newer Python releases and the current Sphinx releases.  Lets see how much work it is to fix it all up.